### PR TITLE
Fix travis node error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,15 @@
 dist: xenial
-language: node_js
-node_js:
-  - 9
+language: php
+php:
+  - '7.0'
 before_install:
   - sudo apt-get update
-  - sudo apt-get install -y php7.0 php7.0-mbstring php7.0-xml ffmpeg imagemagick pngquant gifsicle webp
+  - sudo apt-get install -y php7.0-mbstring php7.0-xml ffmpeg imagemagick pngquant gifsicle webp
+  - nvm install 16
 install:
   - npm install
 script:
   - make
+cache:
+  - npm
+  - .output/icons/**/*.svg


### PR DESCRIPTION
Travis was failing because it was using node 10. This PR updates it to node 16 to match dairybox. 


Also enables some caching of node modules. The svgs rarely change, are small and take a while to process so caching them may be a good idea.

Tavis is not currently running because they moved all the .org stuff to the .com. This means you need to re-auth and re-enable Travis for this repo.